### PR TITLE
CDS Logo:  french homepage logo was out of container's alignment

### DIFF
--- a/_pages/accueil.html
+++ b/_pages/accueil.html
@@ -19,10 +19,9 @@ layout: null
     </div>
     <header role="banner" class="site-header">
       <div class="wrapper">
-       
         {% jekyll_pages_api_search_interface %}
+        <div class="logo"><img alt="cds-snc logo" src="../stylesheets/images/svg/cds-lockup-ko-en.svg" ></div>
       </div>
-      <div class="logo"><img alt="cds-snc logo" src="../stylesheets/images/svg/cds-lockup-ko-en.svg" ></div>
 
     </header>
     <main id="main" role="main">


### PR DESCRIPTION
This will just scope the logo margin with the wrapper margin