### PR TITLE
Dynamic text for language toggle in header

### DIFF
--- a/_includes/lang_toggle.html
+++ b/_includes/lang_toggle.html
@@ -1,0 +1,15 @@
+{% if page.lang == 'en' or page.permalink == '/' %}
+    {% assign translationText = "Français" %}
+{% else %}
+    {% assign translationText = "English" %}
+{% endif %}
+
+{% if page.homepage and page.permalink == '/' %}
+    {% assign translationUrl = "/accueil" %}
+{% elsif page.homepage and page.permalink == '/accueil/' %}
+    {% assign translationUrl = "/" %}
+{% else %}
+    {% assign translationUrl = page.trans_url %}
+{% endif %}
+
+<div class="lang-toggle"> <a class="toggle" href="{{ translationUrl }}">{{translationText}}</a></div>

--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -5,7 +5,7 @@
 </div>
   <div class="gc-banner">
     <div class="gc-logo"><img src="../stylesheets/images/svg/sig-blk-en.svg"/></div>
-    <div class="lang-toggle"> <a class="toggle" href="{{ page.trans_url }}">Français</a></div>
+    {% include lang_toggle.html %}
   </div>
 <header role="banner" class="site-header">
 <div class="wrapper">

--- a/_pages/accueil.html
+++ b/_pages/accueil.html
@@ -1,6 +1,7 @@
 ---
 title: Table of Contents
 permalink: '/accueil/'
+homepage: true
 layout: null
 ---
 <!DOCTYPE html>
@@ -15,7 +16,7 @@ layout: null
     </div>    
     <div class="gc-banner">
       <div class="gc-logo"><img src="../stylesheets/images/svg/sig-blk-en.svg"/></div>
-      <div class="lang-toggle"> <a class="toggle" href="{{site.baseurl}}/">English</a></div>
+      {% include lang_toggle.html %}
     </div>
     <header role="banner" class="site-header">
       <div class="wrapper">

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,6 +1,7 @@
 ---
 title: Table of Contents
 permalink: '/'
+homepage: true
 layout: null
 ---
 
@@ -14,7 +15,7 @@ layout: null
     </div>
         <div class="gc-banner">
           <div class="gc-logo"><img src="../stylesheets/images/svg/sig-blk-en.svg"/></div>
-          <div class="lang-toggle"> <a class="toggle" href="{{site.baseurl}}/accueil">Français</a></div>
+          {% include lang_toggle.html %}
         </div>
     <header role="banner" class="site-header">
       <div class="wrapper">


### PR DESCRIPTION
Lang toggle now says Français or English, accordingly

Language toggle was used in a few places, so I placed it in its own include to avoid any missed updates and to keep the site consistent.

added homepage yaml var to homepages