### PR TITLE
Remove 18F Analytics

### DIFF
--- a/_includes/site-footer.html
+++ b/_includes/site-footer.html
@@ -20,6 +20,4 @@
   {% include fip-footer.html %}
 </footer>
 
-{% guides_style_18f_include analytics.html %}
-
 {% jekyll_pages_api_search_load %}


### PR DESCRIPTION
The Gem file in this repo includes 
```
group :jekyll_plugins do
  gem 'guides_style_18f'
end
```

This was referenced in the footer template and was pulling in the 18F Analytics code(s)

## blocked request
<img width="768" alt="Screen Shot 2019-06-28 at 9 00 43 AM" src="https://user-images.githubusercontent.com/62242/60344255-2232d400-9984-11e9-85ab-1a69432161e5.png">

## source code from current footer
<img width="1008" alt="Screen Shot 2019-06-28 at 9 02 19 AM" src="https://user-images.githubusercontent.com/62242/60344282-324ab380-9984-11e9-8a2b-e18dbe3faa45.png">

